### PR TITLE
Tiny updates to the dynameister.gemspec

### DIFF
--- a/dynameister.gemspec
+++ b/dynameister.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk",                               "~> 2.0"
   spec.add_dependency "dotenv"
-  spec.add_dependency "activesupport",                         "~> 4.2"
+  spec.add_dependency "activesupport",                         "> 4.0"
 
   spec.add_development_dependency "bundler",                   "~> 1.7"
   spec.add_development_dependency "rake",                      "~> 10.0"

--- a/dynameister.gemspec
+++ b/dynameister.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk",                               "~> 2.0"
-  spec.add_dependency "dotenv"
   spec.add_dependency "activesupport",                         "> 4.0"
 
   spec.add_development_dependency "bundler",                   "~> 1.7"
@@ -31,5 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "dotenv"
   spec.add_development_dependency "codeclimate-test-reporter"
 end


### PR DESCRIPTION
This pull request 
* enables the usage of dynameister in Rails 5 apps (by removing the version limit of `ActiveSupport`to 4.x)
* makes dotenv.gem a development-only dependency