### PR TITLE
Make aws region configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,29 @@ Or install it yourself as:
 
 * `DYNAMEISTER_ENV`: defines the environment dynameister is running in, this is mainly important for testing locally and on a CI server as it defines which `/spec/.env.<environment>` file is loaded
 * `DYNAMEISTER_ENDPOINT`: defines the endpoint used by dynameister to access DynamoDB. This should only be necessary when using dynameister locally, in specs and on the CI when a DynamoDB local is in use.
+* `AWS_REGION`: is required by the [AWS SDK to make API calls](http://docs.aws.amazon.com/sdkforruby/api/#Configuration). It can be omitted, or overwritten, if the `region` for the Dynameister is configured explicitly.
+
+### Configuration
+
+Dynameister provides some configuration options:
+
+* `read_capacity`: Defines the **default** provisioned throughput for read requests, see [read capacity units](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html#ProvisionedThroughputIntro.Reads).
+* `write_capacity`: Defines the **default** provisioned throughput for write requests, see [write capacity units](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html#ProvisionedThroughputIntro.Writes).
+* `endpoint`: As mentioned above this is only necessary when [DynamoDB Local](https://aws.amazon.com/de/blogs/aws/dynamodb-local-for-desktop-development/) is used.
+* `region`: Specifies the AWS Region for DynamoDB tables. It overwrites the global configuration of the AWS SDK (e.g. `ENV[‚AWS_REGION‘]`), so that different AWS regions can be used in parallel.
+
+This is how Dynameister can be configured, e.g. in an initializer in a Rails app:
+
+```ruby
+  Dynameister.configure do |config|
+    config.read_capacity 1000
+    config.write_capacity 350
+    # config.endpoint "http://192.168.99.100:32768"
+    config.region "eu-west-1"
+  end
+```
+
+
 
 ### Turn your Model into a Document
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Or install it yourself as:
 
 ### Environment variables
 
-* `DYNAMEISTER_ENV`: defines the environment dynameister is running in, this is mainly important for testing locally and on a CI server as it defines which `/spec/.env.<environment>` file is loaded
-* `DYNAMEISTER_ENDPOINT`: defines the endpoint used by dynameister to access DynamoDB. This should only be necessary when using dynameister locally, in specs and on the CI when a DynamoDB local is in use.
+* `DYNAMEISTER_ENV`: defines the environment Dynameister is running in, this is mainly important for testing locally and on a CI server as it defines which `/spec/.env.<environment>` file is loaded
+* `DYNAMEISTER_ENDPOINT`: defines the endpoint used by Dynameister to access DynamoDB. This should only be necessary when using Dynameister locally, in specs and on the CI when a DynamoDB local is in use.
 * `AWS_REGION`: is required by the [AWS SDK to make API calls](http://docs.aws.amazon.com/sdkforruby/api/#Configuration). It can be omitted, or overwritten, if the `region` for the Dynameister is configured explicitly.
 
 ### Configuration

--- a/lib/dynameister.rb
+++ b/lib/dynameister.rb
@@ -39,6 +39,15 @@ module Dynameister
     end
   end
 
+  # The AWS region for accessing DynamoDB.
+  def self.region(region = nil)
+    if region
+      Thread.current[:region] = region
+    else
+      Thread.current[:region]
+    end
+  end
+
   # The AWS endpoint for accessing DynamoDB.
   def self.endpoint(endpoint = nil)
     if endpoint

--- a/lib/dynameister/client.rb
+++ b/lib/dynameister/client.rb
@@ -81,7 +81,10 @@ module Dynameister
     private
 
     def aws_client_options
-      { endpoint: Dynameister.endpoint }.delete_if { |_, v| v.nil? }
+      {
+        endpoint: Dynameister.endpoint,
+        region:   Dynameister.region
+      }.delete_if { |_, v| v.nil? }
     end
 
   end

--- a/spec/dynameister_spec.rb
+++ b/spec/dynameister_spec.rb
@@ -2,12 +2,14 @@ describe Dynameister do
 
   let(:capacity) { 99 }
   let(:endpoint) { 'foo.bar' }
+  let(:region)   { 'dyna-west-1' }
 
   before :each do
     Dynameister.configure do |config|
       config.read_capacity capacity
       config.write_capacity capacity
       config.endpoint endpoint
+      config.region region
     end
   end
 
@@ -16,6 +18,7 @@ describe Dynameister do
   its(:read_capacity)  { is_expected.to eq(capacity) }
   its(:write_capacity) { is_expected.to eq(capacity) }
   its(:endpoint)       { is_expected.to eq(endpoint) }
+  its(:region)         { is_expected.to eq(region) }
 
   context "when configuration is set on different threads" do
 


### PR DESCRIPTION
This enables the possibility to configure different AWS regions for different AWS services.

Let's say the global AWS region is set to Ireland

```
ENV['AWS_REGION'] = "eu-west-1"
```

but for some reason your DynamoDB table is  in the "Frankfurt" region

```
ENV['AWS_REGION_DYNAMODB'] = "eu-central-1"
```

then you can now configure Dynameister to use this region

```ruby
  Dynameister.configure do |config|
    config.region ENV['AWS_REGION_DYNAMODB'] 
  end