### PR TITLE
Refactor `table_exists?`

### DIFF
--- a/lib/dynameister/persistence.rb
+++ b/lib/dynameister/persistence.rb
@@ -30,7 +30,10 @@ module Dynameister
       end
 
       def table_exists?
-        client.table_names.include? table_name
+        client.describe_table table_name: table_name
+        true
+      rescue Aws::DynamoDB::Errors::ResourceNotFoundException
+        false
       end
 
       def create(attrs = {})

--- a/spec/dynameister/persistence_spec.rb
+++ b/spec/dynameister/persistence_spec.rb
@@ -40,6 +40,22 @@ describe Dynameister::Persistence do
     end
   end
 
+  describe "table_exists?" do
+
+    subject { Language.table_exists? }
+
+    after { delete_table Language.table_name }
+
+    it "returns false if table does not exist" do
+      expect(subject).to be false
+    end
+
+    it "returns true if table exists" do
+      Language.create_table
+      expect(subject).to be true
+    end
+  end
+
   describe "creating a document" do
 
     before { Language.create_table }


### PR DESCRIPTION
Refactor `table_exists?` to use `describe_table` instead of `list_tables`. This enables the use of a more fine grained access control with IAM role based permissions.

For instance: Imagine you have a service that should have full permissions on all of it's DynamoDB tables. Let's call the service *petstore*. It is a Rails app and has a *Dog* and a *Cat* model. Additionally we apply the following naming convention for the DynamoDB tables:

```ruby
	table name: "petstore-#{Rails.env}.dogs"
	{…}
	table name: "petstore-#{Rails.env}.cats"
```

Then you could have an IAM policy like this:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "dynamodb:*"
            ],
            "Resource": [
                "arn:aws:dynamodb:eu-west-1:23423644:table/petstore-staging.*"
            ]
        }
    ]
}
```

If you apply this policy to your application server instance(s), then you can perform any DynamoDB action on any table that is prefixed with `petstore-staging.`, e.g. you can create the `dogs` and `cats` tables with Dynameister. But you wouldn’t be allowed to perform any DynamoDB action on any other table - not even a `list_tables`.

In other words, given the above IAM role, the invocation of `table_exists?` would raise a `Aws::DynamoDB::Errors::AccessDeniedException` exception.

This is what this PR will change.