### PR TITLE
Add configuartion file for CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,24 @@
+---
+engines:
+
+  # https://docs.codeclimate.com/v1.0/docs/bundler-audit
+  bundler-audit:
+    enabled: true
+
+  # https://docs.codeclimate.com/v1.0/docs/duplication
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  # https://docs.codeclimate.com/v1.0/docs/fixme
+  fixme:
+    enabled: true
+
+ratings:
+  paths:
+  - Gemfile.lock
+  - "**.rb"
+
+exclude_paths:
+- spec/


### PR DESCRIPTION
This will just add a basic configuration file for CodeClimate. 

I left out the [Rubocop engine](https://docs.codeclimate.com/v1.0/docs/rubocop) because there seem to be issues with it at the moment.