### PR TITLE
Refactors configuration from Thread.current to Config module

### DIFF
--- a/lib/dynameister.rb
+++ b/lib/dynameister.rb
@@ -1,5 +1,6 @@
 require "active_support"
 require "active_support/core_ext"
+require "dynameister/config"
 require "dynameister/client"
 require "dynameister/table_definition"
 require "dynameister/version"
@@ -15,58 +16,10 @@ require "dynameister/queries"
 require "dynameister/document"
 
 module Dynameister
+  extend self
 
-  # The default read capacity set for new tables.
-  Thread.current[:read_capacity] = 1
-
-  def self.read_capacity(read_capacity = nil)
-    if read_capacity
-      Thread.current[:read_capacity] = read_capacity
-    else
-      Thread.current[:read_capacity]
-    end
-  end
-
-  # The default write capacity set for new tables.
-  Thread.current[:write_capacity] = 1
-
-  def self.write_capacity(write_capacity = nil)
-    if write_capacity
-      Thread.current[:write_capacity] = write_capacity
-    else
-      Thread.current[:write_capacity]
-    end
-  end
-
-  # The AWS region for accessing DynamoDB.
-  def self.region(region = nil)
-    if region
-      Thread.current[:region] = region
-    else
-      Thread.current[:region]
-    end
-  end
-
-  # The AWS endpoint for accessing DynamoDB.
-  def self.endpoint(endpoint = nil)
-    if endpoint
-      Thread.current[:endpoint] = endpoint
-    else
-      Thread.current[:endpoint]
-    end
-  end
-
-  # The AWS credentials for accessing DynamoDB.
-  def self.credentials(credentials = nil)
-    if credentials
-      Thread.current[:credentials] = credentials
-    else
-      Thread.current[:credentials]
-    end
-  end
-
-  def self.configure
-    yield self
+  def configure
+    block_given? ? yield(Dynameister::Config) : Dynameister::Config
   end
 
 end

--- a/lib/dynameister/client.rb
+++ b/lib/dynameister/client.rb
@@ -6,8 +6,8 @@ module Dynameister
 
     def create_table(table_name:, hash_key:, options: {})
       options[:hash_key]       ||= hash_key
-      options[:read_capacity]  ||= Dynameister.read_capacity
-      options[:write_capacity] ||= Dynameister.write_capacity
+      options[:read_capacity]  ||= Dynameister::Config.read_capacity
+      options[:write_capacity] ||= Dynameister::Config.write_capacity
       options[:local_indexes]  ||= []
       options[:global_indexes] ||= []
 
@@ -84,9 +84,9 @@ module Dynameister
 
     def aws_client_options
       {
-        endpoint:    Dynameister.endpoint,
-        region:      Dynameister.region,
-        credentials: Dynameister.credentials
+        endpoint:    Dynameister::Config.endpoint,
+        region:      Dynameister::Config.region,
+        credentials: Dynameister::Config.credentials
       }.delete_if { |_, v| v.nil? }
     end
 

--- a/lib/dynameister/config.rb
+++ b/lib/dynameister/config.rb
@@ -1,0 +1,14 @@
+require "dynameister/config/options"
+
+module Dynameister
+  module Config
+    extend self
+    extend Options
+
+    option :read_capacity, default: 1
+    option :write_capacity, default: 1
+    option :region
+    option :endpoint
+    option :credentials
+  end
+end

--- a/lib/dynameister/config/options.rb
+++ b/lib/dynameister/config/options.rb
@@ -1,0 +1,39 @@
+module Dynameister
+
+  module Config
+
+    module Options
+
+      def defaults
+        @defaults ||= {}
+      end
+
+      def option(name, options = {})
+        defaults[name] = settings[name] = options[:default]
+
+        class_eval <<-RUBY
+          def #{name}
+            settings[#{name.inspect}]
+          end
+          def #{name}=(value)
+            settings[#{name.inspect}] = value
+          end
+          def #{name}?
+            #{name}
+          end
+
+          def reset_#{name}
+            settings[#{name.inspect}] = defaults[#{name.inspect}]
+          end
+        RUBY
+      end
+
+      def settings
+        @settings ||= {}
+      end
+
+    end
+
+  end
+
+end

--- a/spec/dynameister_spec.rb
+++ b/spec/dynameister_spec.rb
@@ -7,50 +7,19 @@ describe Dynameister do
 
   before :each do
     Dynameister.configure do |config|
-      config.read_capacity capacity
-      config.write_capacity capacity
-      config.endpoint endpoint
-      config.region region
+      config.read_capacity  = capacity
+      config.write_capacity = capacity
+      config.endpoint       = endpoint
+      config.region         = region
     end
   end
 
-  subject { Dynameister }
+  subject { Dynameister::Config }
 
   its(:read_capacity)  { is_expected.to eq(capacity) }
   its(:write_capacity) { is_expected.to eq(capacity) }
   its(:endpoint)       { is_expected.to eq(endpoint) }
   its(:region)         { is_expected.to eq(region) }
   its(:credentials)    { is_expected.to be_an(Aws::Credentials) }
-
-  context "when configuration is set on different threads" do
-
-    let(:thread_1_capacity) { 2 }
-    let(:thread_2_capacity) { 9 }
-
-    let(:thread_1) do
-      Thread.new(thread_1_capacity) do |capacity|
-        Dynameister.configure { |config| config.read_capacity capacity }
-
-        Dynameister.read_capacity
-      end
-    end
-
-    let(:thread_2) do
-      Thread.new(thread_2_capacity) do |capacity|
-        Dynameister.configure { |config| config.read_capacity capacity }
-
-        Dynameister.read_capacity
-      end
-    end
-
-    it "sets the proper configuration on thread 1" do
-      expect(thread_1.value).to eq(thread_1_capacity)
-    end
-
-    it "sets the proper configuration on thread 2" do
-      expect(thread_2.value).to eq(thread_2_capacity)
-    end
-
-  end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,9 @@ require "rspec/its"
 require "dynameister"
 
 Dynameister.configure do |config|
-  config.endpoint (ENV["DYNAMEISTER_ENDPOINT"] || "http://localhost:8000")
-  config.region "dynameister-test"
-  config.credentials Aws::Credentials.new("access_key_id", "secret_access_key", "session_token")
+  config.endpoint    = (ENV["DYNAMEISTER_ENDPOINT"] || "http://localhost:8000")
+  config.region      = "dynameister-test"
+  config.credentials = Aws::Credentials.new("access_key_id", "secret_access_key", "session_token")
 end
 
 Dir[File.join(File.dirname(__FILE__), "/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
A `Dynameister::Config` module was added to store the configurations. The `option` DSL simplifies the declaration of an option and its default value.

Fixes #31.